### PR TITLE
Nexus repository search is no longer public. Changed code to use http://search.maven.org/ api.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Usage
      -a,--artifactid <arg>   Module artifactid
      -g,--groupid <arg>      Module groupid
      -h,--help               Show usage information
-     -r,--mavenUrl <arg>     Alternative Nexus repository URL
+     -r,--mavenUrl <arg>     Alternative Maven repository URL
      -s,--sourcedir <arg>    Source directory containing jars
      -t,--targetdir <arg>    Target directory where write ivy build files
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Usage
      -a,--artifactid <arg>   Module artifactid
      -g,--groupid <arg>      Module groupid
      -h,--help               Show usage information
-     -r,--nexusUrl <arg>     Alternative Nexus repository URL
+     -r,--mavenUrl <arg>     Alternative Nexus repository URL
      -s,--sourcedir <arg>    Source directory containing jars
      -t,--targetdir <arg>    Target directory where write ivy build files
 


### PR DESCRIPTION
Nexus repository search is no longer public. Changed code to use http://search.maven.org/ api.

Basically changed the URL to the api provided in search.maven.org .
Changed the way data is parsed from the link (JSON) using jsonSlurper.

Fixed (?) a bug that caused the script to throw an error when all jars were found, When missing.size()  > 0 was false, module tags were created any ways, which were causing problems. 
Added the conditional before module tags as well.